### PR TITLE
fix:vio2display: A segfault error occurs when the sample exits

### DIFF
--- a/debian/app/cdev_demo/vio2display/vio2display.c
+++ b/debian/app/cdev_demo/vio2display/vio2display.c
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
     if (ret)
     {
         printf("[Error] sp_module_bind failed, ret = %d\n", ret);
-        goto error;
+        goto error0;
     }
 
     // 输出 q 退出
@@ -115,7 +115,8 @@ int main(int argc, char **argv)
         }
     }
     printf("Exit!\n");
-
+error0:
+    sp_module_unbind(vio_object, SP_MTYPE_VIO, display_obj, SP_MTYPE_DISPLAY);
 error:
     /*stop module*/
     sp_stop_display(display_obj);


### PR DESCRIPTION
Summary:
	1. When the example exits, it does not perform the module unbinding operation first, but directly destroys the module. As a result, the data flow cannot be forwarded normally, so a segfault occurs. [RDK-60](https://jira.hobot.cc:8443/browse/RDK-60)